### PR TITLE
fixing the json post issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-methods",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Declaratively publish functions for remote invocation.",
   "main": "./server.js",
   "dependencies": {

--- a/src/server/ServerMethod.js
+++ b/src/server/ServerMethod.js
@@ -87,7 +87,6 @@ export default class ServerMethod {
             path: url,
             params: urlParams
           },
-          postBody: args,
           throw: (status, message) => { throw new ServerMethodError(status, this.name, args, message); },
           promise: (func) => { return new Promise(func); },
           http: http

--- a/src/server/ServerMethod.js
+++ b/src/server/ServerMethod.js
@@ -87,6 +87,7 @@ export default class ServerMethod {
             path: url,
             params: urlParams
           },
+          postBody: args,
           throw: (status, message) => { throw new ServerMethodError(status, this.name, args, message); },
           promise: (func) => { return new Promise(func); },
           http: http

--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -121,7 +121,8 @@ const middleware = (server, req, res, next) => {
         const methodVerb = server.match(req.url, req.method);
         if (methodVerb) {
           // Invoke the method.
-          server[INVOKE](methodVerb, req.body.args, req.url)
+          var args = req.body.args || req.body;
+          server[INVOKE](methodVerb, args, req.url)
             .then((result) => { sendJson(result); })
             .catch((err) => {
                 res.statusCode = err.status || 500;

--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -121,7 +121,9 @@ const middleware = (server, req, res, next) => {
         const methodVerb = server.match(req.url, req.method);
         if (methodVerb) {
           // Invoke the method.
-          var args = req.body.args || req.body;
+          let args = req.body.args || req.body;
+          args = _.isArray(args) ? args : [args];
+          
           server[INVOKE](methodVerb, args, req.url)
             .then((result) => { sendJson(result); })
             .catch((err) => {


### PR DESCRIPTION
For some reason, the args in middleware.js never make it to my method, so I put them into the context, which I CAN get to.

The idea is solid, I'm SURE the actual implementation is wrong tho!! Should still work with your req.body.args tho - it'll use that over this.
